### PR TITLE
Fix build failure with Carthage

### DIFF
--- a/SwiftyVK.xcodeproj/xcshareddata/xcschemes/SwiftyVK-OSX.xcscheme
+++ b/SwiftyVK.xcodeproj/xcshareddata/xcschemes/SwiftyVK-OSX.xcscheme
@@ -3,8 +3,8 @@
    LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      parallelizeBuildables = "NO"
+      buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/SwiftyVK.xcodeproj/xcshareddata/xcschemes/SwiftyVK-iOS.xcscheme
+++ b/SwiftyVK.xcodeproj/xcshareddata/xcschemes/SwiftyVK-iOS.xcscheme
@@ -3,8 +3,8 @@
    LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      parallelizeBuildables = "NO"
+      buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"


### PR DESCRIPTION
Not to use “Parallelize Build” and “Find Implicit Dependencies”.

Fixes https://github.com/Carthage/Carthage/issues/945.